### PR TITLE
Plain text indexing

### DIFF
--- a/docloco/controllers.go
+++ b/docloco/controllers.go
@@ -23,7 +23,7 @@ func uploadController(file *multipart.File, filename, name, version string) erro
 	globPath := filepath.Join(dest, globPattern)
 	matches, _ := zglob.Glob(globPath)
 	for _, htmlPath := range matches {
-		if err := indexFile(htmlPath, idx); err != nil {
+		if err := indexFile(htmlPath, name, version, idx); err != nil {
 			return err
 		}
 	}

--- a/docloco/lib.go
+++ b/docloco/lib.go
@@ -15,6 +15,7 @@ import (
 	"mime/multipart"
 	"os"
 	"strings"
+	"github.com/jaytaylor/html2text"
 )
 
 
@@ -47,21 +48,30 @@ func getIndex() (bleve.Index, error) {
 }
 
 // Index the contents of an html file with some basic parsing
-func indexFile(path string, index bleve.Index) error {
+func indexFile(path string, name string, version string, index bleve.Index) error {
 	dat, err := ioutil.ReadFile(path)
 	if err != nil {
 		return err
 	}
+	content := string(dat)
+	plainContent, _ := html2text.FromString(content)
+
 	data := struct {
 		_type   string
 		Content string
 		Path    string
 		Title   string
+		Project string
+		Version string
+		PlainContent string
 	}{
 		_type:   "doc",
-		Content: string(dat),
+		Content: content,
 		Path:    path,
 		Title:   getTitle(string(dat)),
+		Project: name,
+		Version: version,
+		PlainContent: plainContent,
 	}
 	fmt.Println(path)
 

--- a/docloco/views.go
+++ b/docloco/views.go
@@ -6,18 +6,14 @@ import (
 	"log"
 	"net/http"
 	"html/template"
-	"github.com/jaytaylor/html2text"
 )
 
 type displayResult struct {
 	Url string
 	Title string
 	Highlight template.HTML
-}
-
-func cleanHighlight(input string) template.HTML {
-	txt, _ := html2text.FromString(input)
-	return template.HTML(txt)
+	Project string
+	Version string
 }
 
 func searchView(c *gin.Context) {
@@ -33,10 +29,19 @@ func searchView(c *gin.Context) {
 		fmt.Println(searchResults)
 		results := make([]displayResult, len(searchResults.Hits))
 		for i := 0; i < len(searchResults.Hits); i++ {
+			var highlight template.HTML
+			if len(searchResults.Hits[i].Fragments["PlainContent"]) > 0 {
+				highlight = template.HTML(searchResults.Hits[i].Fragments["PlainContent"][0])
+			} else {
+				highlight = template.HTML("")
+			}
+
 			results[i] = displayResult{
 				Url: searchResults.Hits[i].ID,
 				Title: string(searchResults.Hits[i].Fields["Title"].(string)),
-				Highlight: cleanHighlight(searchResults.Hits[i].Fragments["Content"][0]),
+				Highlight: highlight,
+				Project: string(searchResults.Hits[i].Fields["Project"].(string)),
+				Version: string(searchResults.Hits[i].Fields["Version"].(string)),
 			}
 		}
 		c.HTML(http.StatusOK, "results.html", gin.H{

--- a/templates/results.html
+++ b/templates/results.html
@@ -68,7 +68,7 @@ h1 {
         <hr>
         <ul>
             {{ range .results }}
-            <li><a href="{{ .Url }}">{{.Title}}</a>
+            <li><a href="{{ .Url }}">{{.Project}} -> {{.Version}} -> {{.Title}}</a>
                 <p>{{ .Highlight }}</p>
             {{ end }}
         </ul>


### PR DESCRIPTION
Pro:

* Index plain content also.
* Use plain content for nicer highlights
* Index project / version (we can group by those later)
* Template changes to show the new data

Con:

* Still not happy with the plain text version